### PR TITLE
feat: enhance Dockerfile and backup service for PostgreSQL client too…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:20-alpine AS base
 EXPOSE 3000
 
-# Install performance optimizations
+# Install performance optimizations and PostgreSQL 16 client tools
 RUN apk add --no-cache \
     curl \
     libc6-compat \
-    && rm -rf /var/cache/apk/*
+    postgresql16-client \
+    && rm -rf /var/cache/apk/* \
+    && pg_dump --version \
+    && pg_restore --version \
+    && echo "PostgreSQL 16 client tools installed successfully"
 
 FROM base AS pruned
 WORKDIR /app
@@ -18,7 +22,6 @@ EXPOSE 3000
 FROM base AS development
 WORKDIR /app
 COPY ./src ./src
-COPY ./binaries ./binaries
 COPY package.json package-lock.json tsconfig.build.json tsconfig.json .eslintrc.js .prettierrc ./
 RUN npm ci --no-audit --no-fund
 RUN npm run build
@@ -30,14 +33,9 @@ WORKDIR /app
 
 # Copy built application
 COPY --from=development /app/dist ./dist
-COPY --from=development /app/binaries ./binaries
 COPY --from=pruned /app/package.json /app/package-lock.json ./
 COPY --from=pruned /app/node_modules ./node_modules
 
-# Set execute permissions for Linux binaries
-RUN chmod +x ./binaries/linux/bin/* && \
-    ls -la ./binaries/linux/bin/ && \
-    echo "Binary permissions set successfully"
 
 # Set production environment
 ENV NODE_ENV=production

--- a/src/modules/backup/services/backup.service.ts
+++ b/src/modules/backup/services/backup.service.ts
@@ -32,6 +32,21 @@ export class BackupService {
   private async verifyBinaryPermissions(binaryName: string): Promise<void> {
     const binaryPath = getPathOSBinary(binaryName);
 
+    // If using system binary (just the command name), check if it's available in PATH
+    if (binaryPath === binaryName) {
+      try {
+        // Test if the binary is available in PATH
+        await execAsync(`which ${binaryName}`);
+        this.logger.log(`System binary ${binaryName} is available in PATH`);
+        return;
+      } catch (error) {
+        const errorMsg = `System binary ${binaryName} is not available in PATH: ${error.message}`;
+        this.logger.error(errorMsg);
+        throw new Error(errorMsg);
+      }
+    }
+
+    // For custom binaries, check file permissions as before
     try {
       await fs.access(binaryPath, constants.F_OK | constants.X_OK);
       this.logger.log(
@@ -266,37 +281,62 @@ export class BackupService {
     for (const binary of binaries) {
       const binaryPath = getPathOSBinary(binary);
 
-      try {
-        await fs.access(binaryPath, constants.F_OK);
-
+      // Check if using system binary (just the command name)
+      if (binaryPath === binary) {
         try {
-          await fs.access(binaryPath, constants.X_OK);
+          // Test if the binary is available in PATH
+          await execAsync(`which ${binary}`);
           results.push({
             binary,
-            path: binaryPath,
+            path: 'system PATH',
             exists: true,
             executable: true,
-            status: 'OK',
+            status: 'OK (System Binary)',
           });
-        } catch (execError) {
+        } catch (error) {
+          results.push({
+            binary,
+            path: 'system PATH',
+            exists: false,
+            executable: false,
+            status: 'NOT_FOUND_IN_PATH',
+            error: error.message,
+          });
+        }
+      } else {
+        // Check custom binary file
+        try {
+          await fs.access(binaryPath, constants.F_OK);
+
+          try {
+            await fs.access(binaryPath, constants.X_OK);
+            results.push({
+              binary,
+              path: binaryPath,
+              exists: true,
+              executable: true,
+              status: 'OK (Custom Binary)',
+            });
+          } catch (execError) {
+            results.push({
+              binary,
+              path: binaryPath,
+              exists: true,
+              executable: false,
+              status: 'NOT_EXECUTABLE',
+              error: execError.message,
+            });
+          }
+        } catch (error) {
           results.push({
             binary,
             path: binaryPath,
-            exists: true,
+            exists: false,
             executable: false,
-            status: 'NOT_EXECUTABLE',
-            error: execError.message,
+            status: 'NOT_FOUND',
+            error: error.message,
           });
         }
-      } catch (error) {
-        results.push({
-          binary,
-          path: binaryPath,
-          exists: false,
-          executable: false,
-          status: 'NOT_FOUND',
-          error: error.message,
-        });
       }
     }
 

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -197,6 +197,12 @@ export async function preparePath(projectName: string, projectScope: string) {
 }
 
 export function getPathOSBinary(command: string) {
+  // In production (Linux/Alpine), use system-installed PostgreSQL tools
+  if (process.platform === 'linux' && process.env.NODE_ENV === 'production') {
+    return command; // Use system PATH
+  }
+
+  // For development (Windows) or other environments, use bundled binaries
   const osCommand = process.platform === 'win32' ? `${command}.exe` : command;
   const pathCommand = `${process.cwd()}/binaries${
     process.platform === 'win32' ? '/windows/bin/' : '/linux/bin/'


### PR DESCRIPTION
This pull request improves how PostgreSQL client tools are managed and detected in the application, especially in production environments. The main changes include updating the Dockerfile to install PostgreSQL 16 client tools directly, enhancing binary detection logic to prefer system binaries in production, and improving the backup service to distinguish between system and custom binaries.

**Dockerfile and Environment Setup:**

* Added installation of PostgreSQL 16 client tools (`pg_dump`, `pg_restore`) in the production image, with verification steps to ensure they are available.
* Updated the Dockerfile to remove copying and permission-setting for bundled binaries in production, relying on system binaries instead.

**Binary Detection and Usage Logic:**

* Modified `getPathOSBinary` in `src/shared/utils/utils.ts` to return just the command name (using system PATH) for Linux production environments, and continue using bundled binaries for development or Windows.
* Enhanced `BackupService` to check for system binaries in PATH using `which`, and to log and throw errors if not found, distinguishing between system and custom binaries. [[1]](diffhunk://#diff-5514aecf615bb1a09aca6cbbf17d5fa863e74cfd2e2d4f86eaf66602eac8c359R35-R49) [[2]](diffhunk://#diff-5514aecf615bb1a09aca6cbbf17d5fa863e74cfd2e2d4f86eaf66602eac8c359R284-R307)
* Improved binary status reporting in backup diagnostics to clearly indicate whether a binary is a system or custom binary, and to provide more accurate status messages. [[1]](diffhunk://#diff-5514aecf615bb1a09aca6cbbf17d5fa863e74cfd2e2d4f86eaf66602eac8c359L279-R318) [[2]](diffhunk://#diff-5514aecf615bb1a09aca6cbbf17d5fa863e74cfd2e2d4f86eaf66602eac8c359R341)